### PR TITLE
GH-5 Add support for optional excluded-statuses option

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Automatically move issues and pull requests to the next iteration of your [GitHu
 
 ## Example
 
-```yml
+```yaml
 on:
   schedule:
     # Runs "at 05:00, only on Monday" (see https://crontab.guru)
@@ -24,7 +24,32 @@ jobs:
         iteration-field: Iteration
         iteration: last
         new-iteration: current
-        statuses: Todo,In Progress,In Review
+        statuses: 'Todo,In Progress,In Review'
+```
+
+Alternatively, you may specify `excluded-statuses`. In this case, all items that _don’t_ have these statuses will be moved to the new iteration. (Note that if `excluded-statuses` is used, `statuses` will be ignored.)
+
+```yaml
+on:
+  schedule:
+    # Runs "at 05:00, only on Monday" (see https://crontab.guru)
+    - cron: '0 5 * * 1'
+
+jobs:
+  move-to-next-iteration:
+    name: Move to next iteration
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: blombard/move-to-next-iteration@master
+      with:
+        owner: OrgName
+        number: 1
+        token: ${{ secrets.PROJECT_PAT }}
+        iteration-field: Iteration
+        iteration: last
+        new-iteration: current
+        excluded-statuses: "Done,Won't Fix"
 ```
 
 ## Inputs
@@ -49,7 +74,12 @@ Should be `current` or `next`.
 #### statuses
 Statuses of the issues to move to the next iteration.
 
-⚠️ _Don't put an empty string after a comma unless the status starts with an empty string._ ⚠️
+⚠️ _This setting is ignored if `excluded-statuses` is provided. See below._ ⚠️
+
+#### excluded-statuses
+Statuses of the issues that should _not_ be moved.
+
+⚠️ _This setting takes precedence over `statuses`._ ⚠️
 
 ## Sources
 

--- a/action.yml
+++ b/action.yml
@@ -25,7 +25,10 @@ inputs:
     required: true
   statuses:
     description: Statuses of the issues to move to the next iteration.
-    required: true
+    required: false
+  excluded-statuses:
+    description: Statuses of the issues that should not be moved. This setting takes precedence over statuses.
+    required: false
 runs:
   using: 'node16'
   main: 'dist/index.js'

--- a/index.js
+++ b/index.js
@@ -10,6 +10,7 @@ const run = async () => {
     const iterationType = core.getInput('iteration'); // last or current
     const newiterationType = core.getInput('new-iteration'); // current or next
     const statuses = core.getInput('statuses').split(',');
+    const excludedStatuses = core.getInput('excluded-statuses').split(',');
 
     const project = new GitHubProject({ owner, number, token, fields: { iteration: iterationField } });
 
@@ -24,7 +25,18 @@ const run = async () => {
 
     const items = await project.items.list();
 
-    const filteredItems = items.filter(item => statuses.includes(item.fields.status) && item.fields.iteration === iteration.title);
+    const filteredItems = items.filter(item => {
+      // If item is not in the old iteration, return false.
+      if (item.fields.iteration !== iteration.title) return false;
+      // If excludedStatuses are supplied, use that. Otherwise, use statuses.
+      if (excludedStatuses?.length) {
+        // Move item only if its status _is not_ in the excluded statuses list.
+        return !excludedStatuses.includes(item.fields.status);
+      } else {
+        // Move item only if its status _is_ in the statuses list.
+        return statuses.includes(item.fields.status);
+      }
+    });
 
     await Promise.all(filteredItems.map(item => project.items.update(item.id, { iteration: newIteration.title })));
   } catch (error) {


### PR DESCRIPTION
## Description

The changes in this PR add support for selecting tickets via an `excluded-statuses` setting, as opposed to a `statuses` setting. This makes it easier to configure and maintain workflows that use this action on projects where the desire is to move all tickets to a new sprint except for the ones that match one or more statuses.

## Motivation

#5

## How this has been tested

I tested this on one of our project repos by adding and configuring a workflow that can be run manually. That workflow uses the `excluded-statuses` setting, without a `statuses` setting. I then moved a backlog ticket into the last sprint, ran the workflow, and confirmed that the ticket now appears in the current sprint with no other side-effects. See screenshots below.

## Screenshots

Before Workflow Run|After Workflow Run
---|---
![pre-workflow](https://github.com/ChromaticHQ/move-to-next-iteration/assets/439649/2b7e9b55-187e-4224-a93b-e871aed36d74)|![post-workflow](https://github.com/ChromaticHQ/move-to-next-iteration/assets/439649/9413ade0-619e-4c85-aba9-f745c0181412)
Notice ticket 2839 is in Sprint 31 and Sprint 32 shows 9 open tickets.|Ticket 2839 is in Sprint 32, which now shows 10 open tickets. Sprint 31 no longer shows up in this view, indicating there are no tickets in it.

## Documentation

I updated the README and added code comments where it seemed appropriate.