### PR TITLE
Fix Issue #8

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -9824,7 +9824,8 @@ const run = async () => {
     const iterationType = core.getInput('iteration'); // last or current
     const newiterationType = core.getInput('new-iteration'); // current or next
     const statuses = core.getInput('statuses').split(',');
-    const excludedStatuses = core.getInput('excluded-statuses').split(',');
+    const coreExclusedStatuses = core.getInput('excluded-statuses');
+    const excludedStatuses = coreExclusedStatuses ? coreExclusedStatuses.split(',') : [];
 
     const project = new GitHubProject({ owner, number, token, fields: { iteration: iterationField } });
 


### PR DESCRIPTION
The `core.getInput` return a string of length 0 when the value isn't defined.
Then `''.split(',')` returns `['']`


Finally your `if (excludedStatuses?.length) {` always return 1 if `excluded-statuses` isn't defined.